### PR TITLE
[本番でやってない] admin prepare の対応

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -67,6 +67,7 @@ func connectDB(logger echo.Logger) (*sqlx.DB, error) {
 	conf.Passwd = "isucon"
 	conf.DBName = "isupipe"
 	conf.ParseTime = true
+	conf.InterpolateParams = true
 
 	if v, ok := os.LookupEnv(networkTypeEnvKey); ok {
 		conf.Net = v


### PR DESCRIPTION
mysqldumpslow 使ってて謎だった `#` のみ表示されるクエリが気になって本番では使ってなかった pt-query-digest 使って確認したら `administrator command: Prepare` だった。

prepared statement に時間使ってたっぽい。
Go にはアプリケーション側で prepared statement 相当のことをしてクエリとしては直接値を埋め込むようにするオプションがあるらしいのでそれを使うのが正解らしい。
https://www.tetsuzawa.com/docs/ISUCON/go/prepare-interpolateParams/